### PR TITLE
Update service-daemon

### DIFF
--- a/service-daemon
+++ b/service-daemon
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+# shellcheck shell=dash
 
 set -eu
 
@@ -21,14 +22,13 @@ readonly SVDIR
 unset -v _prefix
 
 
-wait_for_pid() (
+wait_for_pid() {
     local pid="$1"
-    local s
+    local seconds
 
-    for s in 1 2 3 4 5
-    do
+    for seconds in 1 2 3 4 5 ; do
         kill -0 "${pid}" 2>/dev/null || break
-        sleep "$s"
+        sleep "${seconds}"
     done
     kill -0 "${pid}" 2>/dev/null && return 1 || return 0
 }
@@ -36,27 +36,26 @@ wait_for_pid() (
 kill_from_pid_file() {
     local pid
 
-    for pid in $(head -n 1 "$1")
-    do
+    for pid in $(head -n 1 "$1") ; do
         kill "${pid}"
         wait_for_pid "${pid}" || kill -9 "${pid}"
     done
 }
 
 start() {
-    mkdir -m 00700 -p "${XDG_RUNTIME_DIR}"
+    # shellcheck disable=SC2174
+    mkdir -m 0700 -p "${XDG_RUNTIME_DIR}"
     start-stop-daemon -S -b -m -p "${PIDFILE}" -x "${DAEMON}" -d "${XDG_RUNTIME_DIR}" -- "${DAEMON_OPTS}"
 }
 
 stop() {
-    local d pid="$(cat "${PIDFILE}")"
+    local dir pid="$(cat "${PIDFILE}")"
 
     start-stop-daemon -K -s "${DAEMON_STOP_SIGNAL}" -o -p "${PIDFILE}"
     wait_for_pid "${pid}" || tail -f --pid="${pid}" /dev/null
-    for d in "${SVDIR}"/*/supervise "${SVDIR}"/*/log/supervise
-    do
-        kill_from_pid_file "${d}/pid"
-        rm -rf "${d}"
+    for dir in "${SVDIR}"/*/{,log/}supervise ; do
+        kill_from_pid_file "${dir}/pid"
+        rm -rf "${dir}"
     done
 }
 

--- a/service-daemon
+++ b/service-daemon
@@ -34,7 +34,7 @@ wait_for_pid() (
 }
 
 kill_from_pid_file() {
-    local pid s
+    local pid
 
     for pid in $(head -n 1 "$1")
     do
@@ -44,17 +44,14 @@ kill_from_pid_file() {
 }
 
 start() {
-    local prefix="${TERMUX__PREFIX:-"${PREFIX}"}"
-    readonly prefix
-
     mkdir -m 00700 -p "${XDG_RUNTIME_DIR}"
-    start-stop-daemon -S -b -m -p "${PIDFILE}" -x "${DAEMON}" -d "${prefix}" -- ${DAEMON_OPTS}
+    start-stop-daemon -S -b -m -p "${PIDFILE}" -x "${DAEMON}" -d "${XDG_RUNTIME_DIR}" -- "${DAEMON_OPTS}"
 }
 
 stop() {
     local d pid="$(cat "${PIDFILE}")"
 
-    start-stop-daemon -K -s 1 -o -p "${PIDFILE}"
+    start-stop-daemon -K -s "${DAEMON_STOP_SIGNAL}" -o -p "${PIDFILE}"
     wait_for_pid "${pid}" || tail -f --pid="${pid}" /dev/null
     for d in "${SVDIR}"/*/supervise "${SVDIR}"/*/log/supervise
     do
@@ -70,15 +67,25 @@ PIDFILE="${XDG_RUNTIME_DIR}/${NAME}.pid"
 # This is the command to be run, give the full pathname
 DAEMON="${BINDIR}/runsvdir"
 DAEMON_OPTS="${SVDIR}"
+# If runsvdir receives a TERM signal, it exits with 0 immediately.
+# If runsvdir receives a HUP signal,
+# it sends a TERM signal to each runsv(8) process it is monitoring and then exits with 111.
+DAEMON_STOP_SIGNAL='HUP'
 
 
 case "$1" in
-    start|stop)
-        printf -- 'S%sing daemon: %s' "$(printf -- '%s\n' "$1" | cut -c 2-)" "${NAME}"
-        "$1"
+    (restart) printf -- 'Restart' ;;
+    (start) printf -- 'Start' ;;
+    (stop) printf -- 'Stopp' ;;
+esac
+case "$1" in
+    (restart|start|stop)
+        printf -- 'ing daemon: %s' "${NAME}"
         ;;
-    restart)
-        printf -- 'Restarting daemon: %s' "${NAME}"
+esac
+case "$1" in
+    (start|stop) "$1" ;;
+    (restart)
         stop
         start
         ;;

--- a/sv-disable
+++ b/sv-disable
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+# shellcheck shell=dash
 
 default_vars() {
     local prefix="${TERMUX__PREFIX:-"${PREFIX}"}"
@@ -23,6 +24,13 @@ if [ -z "$1" ];then
     exit 1
 fi
 
+touch_in_sh() {
+    local file
+    for file in "$@" ; do
+        : >> "${file}"
+    done
+}
+
 default_vars
-: >> "${SVDIR}/${1}/down"
+touch_in_sh "${SVDIR}/${1}/down"
 sv down "$1"

--- a/sv-disable
+++ b/sv-disable
@@ -24,13 +24,6 @@ if [ -z "$1" ];then
     exit 1
 fi
 
-touch_in_sh() {
-    local file
-    for file in "$@" ; do
-        : >> "${file}"
-    done
-}
-
 default_vars
-touch_in_sh "${SVDIR}/${1}/down"
+touch "${SVDIR}/${1}/down"
 sv down "$1"

--- a/sv-enable
+++ b/sv-enable
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+# shellcheck shell=dash
 
 default_vars() {
     local prefix="${TERMUX__PREFIX:-"${PREFIX}"}"


### PR DESCRIPTION
- Document `DAEMON_STOP_SIGNAL`
- Start in `${XDG_RUNTIME_DIR}`
- Use `case` to print the proper message 
- Remove an unused local variable
- Quote `DAEMON_OPTS` because it contains a path
This is only reasonable because `runsvdir` isn't using any other options.
A proper solution, as an example, would use `bash` arrays instead of word splitting a string.